### PR TITLE
docs: drop third-party notices from license so github detects mit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,6 @@
 - Commit subjects are lowercase conventional commits and they are the release notes.
   Write the subject for the person reading the changelog.
 - No `Co-Authored-By` trailer, ever. The person who pushes is the author.
-- Ported or vendored code keeps its attribution in `LICENSE` and its own header.
+- Ported or vendored code keeps its attribution in its own header.
 - Third-party skills and vendored rules are never edited in place. Edit upstream or fork it.
 - No docstrings, no narrative comments, no em dashes.

--- a/LICENSE
+++ b/LICENSE
@@ -19,17 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
---------------------------------------------------------------------------------
-
-Third-party notices
-
-tools/oxlint/anti-slop
-  Copyright (c) 2026 Dillon Mulroy. MIT.
-  https://github.com/dmmulroy/anti-slop
-
-packages/blossom
-  TypeScript port of EdmondsBlossom by Matt Krick. Copyright (c) 2015 mattkrick. MIT.
-  https://github.com/mattkrick/EdmondsBlossom
-  Itself a port of mwmatching.py by Joris van Rantwijk, which states no license.
-  http://jorisvr.nl/article/maximum-matching

--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ Everything else is in [docs/](./docs/README.md).
 
 ## License
 
-MIT. Third-party notices are in [LICENSE](./LICENSE).
+MIT.

--- a/packages/blossom/src/index.ts
+++ b/packages/blossom/src/index.ts
@@ -1,4 +1,4 @@
-// Port of https://github.com/mattkrick/EdmondsBlossom (MIT). Notice in LICENSE.
+// Port of https://github.com/mattkrick/EdmondsBlossom (MIT).
 type Edge = [number, number, number];
 
 const filledArray = <T>(len: number, fill: T): T[] => {


### PR DESCRIPTION
## Why

GitHub showed no license for the repo. Its detector compares the whole file against the canonical MIT text and needs about 98% similarity. The third-party notices appended below the separator dropped it to roughly 87%, so the file was reported as NOASSERTION.

## What

`LICENSE` now holds only the MIT text. The README, AGENTS.md, and the blossom source header no longer point at notices in LICENSE. Upstream attribution stays in the blossom header and in `tools/oxlint/anti-slop/VENDORED.md`.

## Checked

Gate passes locally and in CI. Detection on GitHub only updates after merge, so that is not yet confirmed.